### PR TITLE
chore: Update Promtail sidecar 1.6.0 -> 2.9.8 (latest 2.x release)

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: v8.1.113
 kubeVersion: ">=1.18-0"
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.10.2
+version: 1.10.3
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/README.md
+++ b/charts/unifi/README.md
@@ -173,7 +173,7 @@ ingress:
 | logging.promtail.enabled | bool | `false` | Enable promtail sidecar |
 | logging.promtail.image.pullPolicy | string | `"IfNotPresent"` | Promtail image pull policy. One of `Always`, `Never`, `IfNotPresent` |
 | logging.promtail.image.repository | string | `"grafana/promtail"` | Promtail container image name |
-| logging.promtail.image.tag | string | `"1.6.0"` | Promtail container image tag |
+| logging.promtail.image.tag | string | `"2.9.8"` | Promtail container image tag |
 | logging.promtail.loki.url | string | `"http://loki.logs.svc.cluster.local:3100/loki/api/v1/push"` | Loki backend for promtail sidecar |
 | mongodb.databaseName | string | `"unifi"` | Maps to `unifi.db.name` |
 | mongodb.dbUri | string | `"mongodb://mongo/unifi"` | Maps to `db.mongo.uri` |

--- a/charts/unifi/values.yaml
+++ b/charts/unifi/values.yaml
@@ -299,7 +299,7 @@ logging:
       # -- Promtail container image name
       repository: grafana/promtail
       # -- Promtail container image tag
-      tag: 1.6.0
+      tag: 2.9.8
       # -- Promtail image pull policy. One of `Always`, `Never`, `IfNotPresent`
       pullPolicy: IfNotPresent
     loki:


### PR DESCRIPTION
Replaces:
- #19

Version 1.x is around 4 years old.