### PR TITLE
fix: stun service annotations

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: v8.2.93
 kubeVersion: ">=1.18-0"
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.10.4
+version: 1.10.5
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/templates/stun-svc.yaml
+++ b/charts/unifi/templates/stun-svc.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- end }}
   {{- with .Values.stunService.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if (or (eq .Values.stunService.type "ClusterIP") (empty .Values.stunService.type)) }}


### PR DESCRIPTION
This is the error I got when specifying annotations on the `stunService`
```
Error: YAML parse error on unifi/templates/stun-svc.yaml: error converting YAML to JSON: yaml: line 12: did not find expected key
```

The value file portion:
```
stunService:
  enabled: true
  type: LoadBalancer
  port: 3478
  annotations:
    metallb.universe.tf/loadBalancerIPs: "192.168.1.8"
    metallb.universe.tf/allow-shared-ip: unifi-svc
```

The PR fixes the issue